### PR TITLE
Removed Wiki As A Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "gh-gantt.wiki"]
-	path = gh-gantt.wiki
-	url = git@github.com:Noah-Huppert/gh-gantt.wiki.git
-	branch = master


### PR DESCRIPTION
The wiki was not a dependency of the code, did not make sense for it to be a submodule.